### PR TITLE
Standardised the response format

### DIFF
--- a/src/main/java/pl/eukon05/eventboard/common/GlobalValidationExceptionHandler.java
+++ b/src/main/java/pl/eukon05/eventboard/common/GlobalValidationExceptionHandler.java
@@ -1,0 +1,29 @@
+package pl.eukon05.eventboard.common;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+final class GlobalValidationExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResultWrapper> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+
+        ex.getBindingResult().getAllErrors().forEach(error -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+
+        ResultWrapper wrapper = ResultWrapper.builder().result(Result.VALIDATION_FAILED).details(errors).build();
+        return ResponseEntity.status(wrapper.getStatus()).body(wrapper);
+    }
+
+}

--- a/src/main/java/pl/eukon05/eventboard/common/Result.java
+++ b/src/main/java/pl/eukon05/eventboard/common/Result.java
@@ -23,7 +23,8 @@ public enum Result {
     NOT_ORGANIZER(HttpStatus.FORBIDDEN, "You are not the organizer of the given event and thus cannot modify it"),
     EVENT_ALREADY_PUBLIC(HttpStatus.BAD_REQUEST, "This event is already public"),
     FRIEND_REQUEST_ALREADY_SENT(HttpStatus.BAD_REQUEST, "You already sent a friend request to this user"),
-    FRIEND_NOT_REQUESTED(HttpStatus.BAD_REQUEST, "This user has not sent you a friend request");
+    FRIEND_NOT_REQUESTED(HttpStatus.BAD_REQUEST, "This user has not sent you a friend request"),
+    VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "Validation of your input was not successful");
 
 
     private final HttpStatus status;

--- a/src/main/java/pl/eukon05/eventboard/common/ResultWrapper.java
+++ b/src/main/java/pl/eukon05/eventboard/common/ResultWrapper.java
@@ -1,29 +1,64 @@
 package pl.eukon05.eventboard.common;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Builder
 @Getter
 public class ResultWrapper {
 
+    @JsonIgnore
+    public static final String CREATED_RESOURCE_ID = "createdResourceID";
+
+    @JsonIgnore
     private final Result result;
-    private final Object content;
 
-    private ResultWrapper(Result result) {
-        this.result = result;
-        this.content = result.getMessage();
+    private Object data;
+    private Map<String, String> details;
+
+    //Two special getter methods for Spring to automatically convert into JSON
+    public HttpStatus getStatus() {
+        return result.getStatus();
     }
 
-    private ResultWrapper(Result result, Object content) {
-        this.result = result;
-        this.content = content;
+    public String getMessage() {
+        return result.getMessage();
     }
 
-    public static ResultWrapper of(Result result) {
-        return new ResultWrapper(result);
+    //Override for the auto-generated builder
+    public static class ResultWrapperBuilder {
+        private static final String NO_CONTENT = "";
+
+        //Override for the auto-generated build method
+        public ResultWrapper build() {
+            if (details == null)
+                details = Collections.emptyMap();
+
+            if (data == null)
+                data = NO_CONTENT;
+
+            return new ResultWrapper(result, data, details);
+        }
+
+        public ResultWrapperBuilder createdResourceID(long id) {
+            if (details == null)
+                details = new HashMap<>();
+
+            details.put(CREATED_RESOURCE_ID, String.valueOf(id));
+
+            return this;
+        }
     }
 
-    public static ResultWrapper of(Result result, Object content) {
-        return new ResultWrapper(result, content);
+    //A method to easily "wrap" the Result object, when it's the only data returned by a use case
+    public static ResultWrapper wrap(Result result) {
+        return builder().result(result).build();
     }
 
 }

--- a/src/main/java/pl/eukon05/eventboard/event/adapter/in/web/EventController.java
+++ b/src/main/java/pl/eukon05/eventboard/event/adapter/in/web/EventController.java
@@ -3,20 +3,20 @@ package pl.eukon05.eventboard.event.adapter.in.web;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import pl.eukon05.eventboard.common.Result;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import pl.eukon05.eventboard.common.ResultWrapper;
 import pl.eukon05.eventboard.event.application.port.in.command.CreateEventCommand;
 import pl.eukon05.eventboard.event.application.port.in.command.ModifyEventCommand;
-import pl.eukon05.eventboard.event.application.port.out.dto.EventDTO;
 import pl.eukon05.eventboard.event.application.service.EventFacade;
 
+import java.net.URI;
 import java.security.Principal;
 import java.util.Map;
+
+import static pl.eukon05.eventboard.common.ResultWrapper.CREATED_RESOURCE_ID;
 
 @RestController
 @RequestMapping("/event")
@@ -25,74 +25,81 @@ class EventController {
     private final EventFacade facade;
 
     @PostMapping
-    ResponseEntity<String> createEvent(Principal principal, @RequestBody @Valid CreateEventCommand dto) {
-        Result result = facade.createEvent(principal.getName(), dto);
-        return ResponseEntity.status(result.getStatus()).body(result.getMessage());
+    ResponseEntity<ResultWrapper> createEvent(Principal principal, @RequestBody @Valid CreateEventCommand dto) {
+        ResultWrapper result = facade.createEvent(principal.getName(), dto);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(result.getDetails().get(CREATED_RESOURCE_ID))
+                .toUri();
+
+        return ResponseEntity.created(location).body(result);
     }
 
     @PostMapping("/{id}/publish")
-    ResponseEntity<String> publishEvent(Principal principal, @PathVariable long id) {
-        Result result = facade.publishEvent(principal.getName(), id);
-        return ResponseEntity.status(result.getStatus()).body(result.getMessage());
+    ResponseEntity<ResultWrapper> publishEvent(Principal principal, @PathVariable long id) {
+        ResultWrapper result = facade.publishEvent(principal.getName(), id);
+        return ResponseEntity.status(result.getStatus()).body(result);
     }
 
     @PostMapping("/{id}/invite")
-    ResponseEntity<String> inviteToEvent(Principal principal, @PathVariable long id, @RequestParam String friendID) {
-        Result result = facade.inviteToEvent(principal.getName(), friendID, id);
-        return ResponseEntity.status(result.getStatus()).body(result.getMessage());
+    ResponseEntity<ResultWrapper> inviteToEvent(Principal principal, @PathVariable long id, @RequestParam String friendID) {
+        ResultWrapper result = facade.inviteToEvent(principal.getName(), friendID, id);
+        return ResponseEntity.status(result.getStatus()).body(result);
     }
 
     @PostMapping("/{id}/attend")
-    ResponseEntity<String> attendEvent(Principal principal, @PathVariable long id) {
-        Result result = facade.attendEvent(principal.getName(), id);
-        return ResponseEntity.status(result.getStatus()).body(result.getMessage());
+    ResponseEntity<ResultWrapper> attendEvent(Principal principal, @PathVariable long id) {
+        ResultWrapper result = facade.attendEvent(principal.getName(), id);
+        return ResponseEntity.status(result.getStatus()).body(result);
     }
 
     @PostMapping("/{id}/unattend")
-    ResponseEntity<String> unattendEvent(Principal principal, @PathVariable long id) {
-        Result result = facade.unattendEvent(principal.getName(), id);
-        return ResponseEntity.status(result.getStatus()).body(result.getMessage());
+    ResponseEntity<ResultWrapper> unattendEvent(Principal principal, @PathVariable long id) {
+        ResultWrapper result = facade.unattendEvent(principal.getName(), id);
+        return ResponseEntity.status(result.getStatus()).body(result);
     }
 
     @DeleteMapping("/{id}")
-    ResponseEntity<String> deleteEvent(Principal principal, @PathVariable long id) {
-        Result result = facade.deleteEvent(principal.getName(), id);
-        return ResponseEntity.status(result.getStatus()).body(result.getMessage());
+    ResponseEntity<ResultWrapper> deleteEvent(Principal principal, @PathVariable long id) {
+        ResultWrapper result = facade.deleteEvent(principal.getName(), id);
+        return ResponseEntity.status(result.getStatus()).body(result);
     }
 
     @PatchMapping("/{id}")
-    ResponseEntity<String> modifyEvent(Principal principal, @PathVariable long id, @RequestBody @Valid ModifyEventCommand command) {
-        Result result = facade.modifyEvent(principal.getName(), id, command);
-        return ResponseEntity.status(result.getStatus()).body(result.getMessage());
+    ResponseEntity<ResultWrapper> modifyEvent(Principal principal, @PathVariable long id, @RequestBody @Valid ModifyEventCommand command) {
+        ResultWrapper result = facade.modifyEvent(principal.getName(), id, command);
+        return ResponseEntity.status(result.getStatus()).body(result);
     }
 
     @GetMapping
-    ResponseEntity<Page<EventDTO>> search(@ParameterObject Pageable pageable, @RequestParam(required = false) Map<String, String> params) {
-        Page<EventDTO> page = facade.searchForEvent(params, pageable);
-        return ResponseEntity.status(HttpStatus.OK).body(page);
+    ResponseEntity<ResultWrapper> search(@ParameterObject Pageable pageable, @RequestParam(required = false) Map<String, String> params) {
+        ResultWrapper result = facade.searchForEvent(params, pageable);
+        return ResponseEntity.status(result.getStatus()).body(result);
     }
 
     @GetMapping("{id}")
-    ResponseEntity<Object> getEvent(Principal principal, @PathVariable long id) {
+    ResponseEntity<ResultWrapper> getEvent(Principal principal, @PathVariable long id) {
         ResultWrapper wrapper = facade.getEvent(principal.getName(), id);
-        return ResponseEntity.status(wrapper.getResult().getStatus()).body(wrapper.getContent());
+        return ResponseEntity.status(wrapper.getStatus()).body(wrapper);
     }
 
     @GetMapping("/attended")
-    ResponseEntity<Object> getAttended(Principal principal, @ParameterObject Pageable pageable) {
-        Page<EventDTO> page = facade.searchForAttended(principal.getName(), pageable);
-        return ResponseEntity.status(HttpStatus.OK).body(page);
+    ResponseEntity<ResultWrapper> getAttended(Principal principal, @ParameterObject Pageable pageable) {
+        ResultWrapper result = facade.searchForAttended(principal.getName(), pageable);
+        return ResponseEntity.status(result.getStatus()).body(result);
     }
 
     @GetMapping("/invited")
-    ResponseEntity<Object> getInvited(Principal principal, @ParameterObject Pageable pageable) {
-        Page<EventDTO> page = facade.searchForInvited(principal.getName(), pageable);
-        return ResponseEntity.status(HttpStatus.OK).body(page);
+    ResponseEntity<ResultWrapper> getInvited(Principal principal, @ParameterObject Pageable pageable) {
+        ResultWrapper result = facade.searchForInvited(principal.getName(), pageable);
+        return ResponseEntity.status(result.getStatus()).body(result);
     }
 
     @GetMapping("/organized")
-    ResponseEntity<Object> getOrganized(Principal principal, @ParameterObject Pageable pageable) {
-        Page<EventDTO> page = facade.searchForOrganized(principal.getName(), pageable);
-        return ResponseEntity.status(HttpStatus.OK).body(page);
+    ResponseEntity<ResultWrapper> getOrganized(Principal principal, @ParameterObject Pageable pageable) {
+        ResultWrapper result = facade.searchForOrganized(principal.getName(), pageable);
+        return ResponseEntity.status(result.getStatus()).body(result);
     }
 }

--- a/src/main/java/pl/eukon05/eventboard/event/application/service/CreateEventUseCase.java
+++ b/src/main/java/pl/eukon05/eventboard/event/application/service/CreateEventUseCase.java
@@ -2,7 +2,6 @@ package pl.eukon05.eventboard.event.application.service;
 
 
 import lombok.RequiredArgsConstructor;
-import pl.eukon05.eventboard.common.Result;
 import pl.eukon05.eventboard.common.UseCase;
 import pl.eukon05.eventboard.event.application.port.in.command.CreateEventCommand;
 import pl.eukon05.eventboard.event.application.port.in.command.EventCommandMapper;
@@ -16,12 +15,11 @@ class CreateEventUseCase {
     private final SaveEventPort saveEventPort;
     private final EventCommandMapper mapper;
 
-    Result create(String userId, CreateEventCommand command) {
+    long create(String userId, CreateEventCommand command) {
         Event event = mapper.mapCreateCommandToDomain(command);
         event.setType(EventType.PRIVATE);
         event.setOrganizerID(userId);
 
-        saveEventPort.saveEvent(event);
-        return Result.SUCCESS;
+        return saveEventPort.saveEvent(event);
     }
 }

--- a/src/main/java/pl/eukon05/eventboard/event/application/service/EventFacade.java
+++ b/src/main/java/pl/eukon05/eventboard/event/application/service/EventFacade.java
@@ -1,14 +1,12 @@
 package pl.eukon05.eventboard.event.application.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import pl.eukon05.eventboard.common.Result;
 import pl.eukon05.eventboard.common.ResultWrapper;
 import pl.eukon05.eventboard.event.application.port.in.command.CreateEventCommand;
 import pl.eukon05.eventboard.event.application.port.in.command.ModifyEventCommand;
-import pl.eukon05.eventboard.event.application.port.out.dto.EventDTO;
 
 import java.util.Map;
 
@@ -23,48 +21,61 @@ public class EventFacade {
     private final PublishEventUseCase publishEventUseCase;
     private final GetEventUseCase getEventUseCase;
 
-    public Result createEvent(String userID, CreateEventCommand command) {
-        return createEventUseCase.create(userID, command);
+    public ResultWrapper createEvent(String userID, CreateEventCommand command) {
+        long id = createEventUseCase.create(userID, command);
+        return ResultWrapper.builder().result(Result.SUCCESS).createdResourceID(id).build();
     }
 
-    public Result publishEvent(String userID, long eventID) {
-        return publishEventUseCase.publish(userID, eventID);
+    public ResultWrapper publishEvent(String userID, long eventID) {
+        return ResultWrapper.wrap(publishEventUseCase.publish(userID, eventID));
     }
 
-    public Result attendEvent(String userID, long eventID) {
-        return manageEventAttendanceUseCase.attend(userID, eventID);
+    public ResultWrapper attendEvent(String userID, long eventID) {
+        return ResultWrapper.wrap(manageEventAttendanceUseCase.attend(userID, eventID));
     }
 
-    public Result unattendEvent(String userID, long eventID) {
-        return manageEventAttendanceUseCase.unattend(userID, eventID);
+    public ResultWrapper unattendEvent(String userID, long eventID) {
+        return ResultWrapper.wrap(manageEventAttendanceUseCase.unattend(userID, eventID));
     }
 
-    public Result inviteToEvent(String userID, String friendID, long eventID) {
-        return inviteToEventUseCase.invite(userID, friendID, eventID);
+    public ResultWrapper inviteToEvent(String userID, String friendID, long eventID) {
+        return ResultWrapper.wrap(inviteToEventUseCase.invite(userID, friendID, eventID));
     }
 
-    public Result deleteEvent(String userID, long eventID) {
-        return deleteEventUseCase.delete(userID, eventID);
+    public ResultWrapper deleteEvent(String userID, long eventID) {
+        return ResultWrapper.wrap(deleteEventUseCase.delete(userID, eventID));
     }
 
-    public Page<EventDTO> searchForEvent(Map<String, String> parameters, Pageable pageable) {
-        return getEventUseCase.search(parameters, pageable);
+    public ResultWrapper searchForEvent(Map<String, String> parameters, Pageable pageable) {
+        return ResultWrapper.builder().result(Result.SUCCESS).data(getEventUseCase.search(parameters, pageable)).build();
     }
 
-    public Page<EventDTO> searchForAttended(String userID, Pageable pageable) {
-        return getEventUseCase.getAttendedByUser(userID, pageable);
+    public ResultWrapper searchForAttended(String userID, Pageable pageable) {
+        return ResultWrapper
+                .builder()
+                .result(Result.SUCCESS)
+                .data(getEventUseCase.getAttendedByUser(userID, pageable))
+                .build();
     }
 
-    public Page<EventDTO> searchForInvited(String userID, Pageable pageable) {
-        return getEventUseCase.getInvitedForUser(userID, pageable);
+    public ResultWrapper searchForInvited(String userID, Pageable pageable) {
+        return ResultWrapper
+                .builder()
+                .result(Result.SUCCESS)
+                .data(getEventUseCase.getInvitedForUser(userID, pageable))
+                .build();
     }
 
-    public Page<EventDTO> searchForOrganized(String userID, Pageable pageable) {
-        return getEventUseCase.getOrganizedByUser(userID, pageable);
+    public ResultWrapper searchForOrganized(String userID, Pageable pageable) {
+        return ResultWrapper
+                .builder()
+                .result(Result.SUCCESS)
+                .data(getEventUseCase.getOrganizedByUser(userID, pageable))
+                .build();
     }
 
-    public Result modifyEvent(String userID, long eventID, ModifyEventCommand command) {
-        return modifyEventUseCase.modify(userID, eventID, command);
+    public ResultWrapper modifyEvent(String userID, long eventID, ModifyEventCommand command) {
+        return ResultWrapper.wrap(modifyEventUseCase.modify(userID, eventID, command));
     }
 
     public ResultWrapper getEvent(String userID, long eventID) {

--- a/src/main/java/pl/eukon05/eventboard/event/application/service/GetEventUseCase.java
+++ b/src/main/java/pl/eukon05/eventboard/event/application/service/GetEventUseCase.java
@@ -24,14 +24,14 @@ class GetEventUseCase {
     ResultWrapper getById(String userID, long eventID) {
         Optional<Event> eventOptional = getEventPort.getById(eventID);
 
-        if (eventOptional.isEmpty()) return ResultWrapper.of(Result.EVENT_NOT_FOUND);
+        if (eventOptional.isEmpty()) return ResultWrapper.wrap(Result.EVENT_NOT_FOUND);
 
         Event event = eventOptional.get();
 
         if (event.getType().equals(EventType.PRIVATE) && !event.getOrganizerID().equals(userID) && !event.getGuestIDs().contains(userID) && !event.getInviteeIDs().contains(userID))
-            return ResultWrapper.of(Result.EVENT_PRIVATE);
+            return ResultWrapper.wrap(Result.EVENT_PRIVATE);
 
-        return ResultWrapper.of(Result.SUCCESS, mapper.mapDomainToDTO(event));
+        return ResultWrapper.builder().result(Result.SUCCESS).data(mapper.mapDomainToDTO(event)).build();
     }
 
     Page<EventDTO> search(Map<String, String> parameters, Pageable pageable) {

--- a/src/main/java/pl/eukon05/eventboard/user/adapter/in/web/UserController.java
+++ b/src/main/java/pl/eukon05/eventboard/user/adapter/in/web/UserController.java
@@ -3,7 +3,6 @@ package pl.eukon05.eventboard.user.adapter.in.web;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import pl.eukon05.eventboard.common.Result;
 import pl.eukon05.eventboard.common.ResultWrapper;
 import pl.eukon05.eventboard.user.application.service.UserFacade;
 
@@ -17,38 +16,38 @@ class UserController {
     private final UserFacade facade;
 
     @PostMapping("/{id}/befriend")
-    ResponseEntity<String> befriendUser(Principal principal, @PathVariable String id) {
-        Result result = facade.createFriendRequest(principal.getName(), id);
-        return new ResponseEntity<>(result.getMessage(), result.getStatus());
+    ResponseEntity<ResultWrapper> befriendUser(Principal principal, @PathVariable String id) {
+        ResultWrapper result = facade.createFriendRequest(principal.getName(), id);
+        return ResponseEntity.status(result.getStatus()).body(result);
     }
 
     @PostMapping("/{id}/accept")
-    ResponseEntity<String> acceptFriendRequest(Principal principal, @PathVariable String id) {
-        Result result = facade.acceptFriendRequest(principal.getName(), id);
-        return new ResponseEntity<>(result.getMessage(), result.getStatus());
+    ResponseEntity<ResultWrapper> acceptFriendRequest(Principal principal, @PathVariable String id) {
+        ResultWrapper result = facade.acceptFriendRequest(principal.getName(), id);
+        return ResponseEntity.status(result.getStatus()).body(result);
     }
 
     @PostMapping("/{id}/reject")
-    ResponseEntity<String> rejectFriendRequest(Principal principal, @PathVariable String id) {
-        Result result = facade.rejectFriendRequest(principal.getName(), id);
-        return new ResponseEntity<>(result.getMessage(), result.getStatus());
+    ResponseEntity<ResultWrapper> rejectFriendRequest(Principal principal, @PathVariable String id) {
+        ResultWrapper result = facade.rejectFriendRequest(principal.getName(), id);
+        return ResponseEntity.status(result.getStatus()).body(result);
     }
 
     @PostMapping("/{id}/defriend")
-    ResponseEntity<String> defriendUser(Principal principal, @PathVariable String id) {
-        Result result = facade.removeFriend(principal.getName(), id);
-        return new ResponseEntity<>(result.getMessage(), result.getStatus());
+    ResponseEntity<ResultWrapper> defriendUser(Principal principal, @PathVariable String id) {
+        ResultWrapper result = facade.removeFriend(principal.getName(), id);
+        return ResponseEntity.status(result.getStatus()).body(result);
     }
 
     @GetMapping("/friends")
-    ResponseEntity<Object> getFriends(Principal principal) {
+    ResponseEntity<ResultWrapper> getFriends(Principal principal) {
         ResultWrapper result = facade.getFriends(principal.getName());
-        return ResponseEntity.status(result.getResult().getStatus()).body(result.getContent());
+        return ResponseEntity.status(result.getStatus()).body(result);
     }
 
     @GetMapping("/friends/requests")
-    ResponseEntity<Object> getFriendRequests(Principal principal) {
+    ResponseEntity<ResultWrapper> getFriendRequests(Principal principal) {
         ResultWrapper result = facade.getFriendRequests(principal.getName());
-        return ResponseEntity.status(result.getResult().getStatus()).body(result.getContent());
+        return ResponseEntity.status(result.getStatus()).body(result);
     }
 }

--- a/src/main/java/pl/eukon05/eventboard/user/application/service/GetFriendsUseCase.java
+++ b/src/main/java/pl/eukon05/eventboard/user/application/service/GetFriendsUseCase.java
@@ -18,19 +18,19 @@ class GetFriendsUseCase {
     ResultWrapper getFriends(String userID) {
         Optional<User> userOptional = getUserPort.getUserById(userID);
 
-        if (userOptional.isEmpty()) return ResultWrapper.of(Result.USER_NOT_FOUND);
+        if (userOptional.isEmpty()) return ResultWrapper.wrap(Result.USER_NOT_FOUND);
 
         Set<String> friendIDs = userOptional.get().getFriendIDs();
-        return ResultWrapper.of(Result.SUCCESS, friendIDs);
+        return ResultWrapper.builder().result(Result.SUCCESS).data(friendIDs).build();
     }
 
     ResultWrapper getFriendRequests(String userID) {
         Optional<User> userOptional = getUserPort.getUserById(userID);
 
-        if (userOptional.isEmpty()) return ResultWrapper.of(Result.USER_NOT_FOUND);
+        if (userOptional.isEmpty()) return ResultWrapper.wrap(Result.USER_NOT_FOUND);
 
         Set<String> friendRequestIDs = userOptional.get().getFriendRequestIDs();
-        return ResultWrapper.of(Result.SUCCESS, friendRequestIDs);
+        return ResultWrapper.builder().result(Result.SUCCESS).data(friendRequestIDs).build();
     }
 
 }

--- a/src/main/java/pl/eukon05/eventboard/user/application/service/UserFacade.java
+++ b/src/main/java/pl/eukon05/eventboard/user/application/service/UserFacade.java
@@ -2,7 +2,6 @@ package pl.eukon05.eventboard.user.application.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import pl.eukon05.eventboard.common.Result;
 import pl.eukon05.eventboard.common.ResultWrapper;
 import pl.eukon05.eventboard.user.application.port.in.CheckIfFriendsPort;
 
@@ -16,20 +15,20 @@ public class UserFacade implements CheckIfFriendsPort {
     private final ManageFriendRequestUseCase manageFriendRequestUseCase;
     private final GetFriendsUseCase getFriendsUseCase;
 
-    public Result createFriendRequest(String selfID, String friendID) {
-        return createFriendRequestUseCase.createFriendRequest(selfID, friendID);
+    public ResultWrapper createFriendRequest(String selfID, String friendID) {
+        return ResultWrapper.wrap(createFriendRequestUseCase.createFriendRequest(selfID, friendID));
     }
 
-    public Result acceptFriendRequest(String selfID, String friendID) {
-        return manageFriendRequestUseCase.acceptFriendRequest(selfID, friendID);
+    public ResultWrapper acceptFriendRequest(String selfID, String friendID) {
+        return ResultWrapper.wrap(manageFriendRequestUseCase.acceptFriendRequest(selfID, friendID));
     }
 
-    public Result rejectFriendRequest(String selfID, String friendID) {
-        return manageFriendRequestUseCase.rejectFriendRequest(selfID, friendID);
+    public ResultWrapper rejectFriendRequest(String selfID, String friendID) {
+        return ResultWrapper.wrap(manageFriendRequestUseCase.rejectFriendRequest(selfID, friendID));
     }
 
-    public Result removeFriend(String selfID, String friendID) {
-        return removeFriendUseCase.removeFriend(selfID, friendID);
+    public ResultWrapper removeFriend(String selfID, String friendID) {
+        return ResultWrapper.wrap(removeFriendUseCase.removeFriend(selfID, friendID));
     }
 
     @Override

--- a/src/test/java/pl/eukon05/eventboard/event/application/service/GetEventUnitTests.java
+++ b/src/test/java/pl/eukon05/eventboard/event/application/service/GetEventUnitTests.java
@@ -37,7 +37,7 @@ class GetEventUnitTests {
 
         ResultWrapper wrapper = getEventUseCase.getById(userID, event.getId());
         assertEquals(Result.EVENT_PRIVATE, wrapper.getResult());
-        assertEquals(Result.EVENT_PRIVATE.getMessage(), wrapper.getContent());
+        assertEquals(Result.EVENT_PRIVATE.getMessage(), wrapper.getMessage());
     }
 
     @Test

--- a/src/test/java/pl/eukon05/eventboard/integration/AbstractIntegrationTest.java
+++ b/src/test/java/pl/eukon05/eventboard/integration/AbstractIntegrationTest.java
@@ -29,7 +29,7 @@ public abstract class AbstractIntegrationTest {
     }
 
     @BeforeEach
-    public void cleanUp() {
+    void cleanUp() {
         utils.cleanUp();
     }
 }

--- a/src/test/java/pl/eukon05/eventboard/integration/user/CreateFriendRequestIntegrationTests.java
+++ b/src/test/java/pl/eukon05/eventboard/integration/user/CreateFriendRequestIntegrationTests.java
@@ -21,11 +21,11 @@ class CreateFriendRequestIntegrationTests extends AbstractIntegrationTest {
 
         utils.sendAPIPostRequest(BEFRIEND_USER_TWO_URL, tokenOne)
                 .statusCode(HttpStatus.SC_SUCCESS)
-                .body(equalTo(Result.SUCCESS.getMessage()));
+                .body("message", equalTo(Result.SUCCESS.getMessage()));
 
         utils.sendAPIGETRequest(REQUESTS_URL, tokenTwo)
                 .statusCode(HttpStatus.SC_SUCCESS)
-                .body("[0]", equalTo(USER_ONE));
+                .body("data[0]", equalTo(USER_ONE));
     }
 
     @Test
@@ -36,7 +36,7 @@ class CreateFriendRequestIntegrationTests extends AbstractIntegrationTest {
 
         utils.sendAPIPostRequest(BEFRIEND_USER_TWO_URL, tokenOne)
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
-                .body(equalTo(Result.USER_ALREADY_FRIEND.getMessage()));
+                .body("message", equalTo(Result.USER_ALREADY_FRIEND.getMessage()));
     }
 
     @Test
@@ -45,11 +45,11 @@ class CreateFriendRequestIntegrationTests extends AbstractIntegrationTest {
 
         utils.sendAPIPostRequest(BEFRIEND_USER_TWO_URL, tokenOne)
                 .statusCode(HttpStatus.SC_SUCCESS)
-                .body(equalTo(Result.SUCCESS.getMessage()));
+                .body("message", equalTo(Result.SUCCESS.getMessage()));
 
         utils.sendAPIPostRequest(BEFRIEND_USER_TWO_URL, tokenOne)
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
-                .body(equalTo(Result.FRIEND_REQUEST_ALREADY_SENT.getMessage()));
+                .body("message", equalTo(Result.FRIEND_REQUEST_ALREADY_SENT.getMessage()));
     }
 
 }

--- a/src/test/java/pl/eukon05/eventboard/integration/user/GetFriendsIntegrationTests.java
+++ b/src/test/java/pl/eukon05/eventboard/integration/user/GetFriendsIntegrationTests.java
@@ -22,7 +22,7 @@ class GetFriendsIntegrationTests extends AbstractIntegrationTest {
 
         utils.sendAPIGETRequest(FRIENDS_URL, tokenTwo)
                 .statusCode(HttpStatus.SC_SUCCESS)
-                .body("", equalTo(List.of(USER_ONE)));
+                .body("data", equalTo(List.of(USER_ONE)));
     }
 
     @Test
@@ -31,7 +31,7 @@ class GetFriendsIntegrationTests extends AbstractIntegrationTest {
 
         utils.sendAPIGETRequest(FRIENDS_URL, tokenTwo)
                 .statusCode(HttpStatus.SC_SUCCESS)
-                .body("", equalTo(Collections.emptyList()));
+                .body("data", equalTo(Collections.emptyList()));
     }
 
 }

--- a/src/test/java/pl/eukon05/eventboard/integration/user/ManageFriendRequestIntegrationTests.java
+++ b/src/test/java/pl/eukon05/eventboard/integration/user/ManageFriendRequestIntegrationTests.java
@@ -27,7 +27,7 @@ class ManageFriendRequestIntegrationTests extends AbstractIntegrationTest {
 
         utils.sendAPIPostRequest(ACCEPT_USER_ONE_URL, tokenTwo)
                 .statusCode(HttpStatus.SC_SUCCESS)
-                .body(equalTo(Result.SUCCESS.getMessage()));
+                .body("message", equalTo(Result.SUCCESS.getMessage()));
 
         checkThereAreNoRequests(tokenTwo);
     }
@@ -41,7 +41,7 @@ class ManageFriendRequestIntegrationTests extends AbstractIntegrationTest {
 
         utils.sendAPIPostRequest(REJECT_USER_ONE_URL, tokenTwo)
                 .statusCode(HttpStatus.SC_SUCCESS)
-                .body(equalTo(Result.SUCCESS.getMessage()));
+                .body("message", equalTo(Result.SUCCESS.getMessage()));
 
         checkThereAreNoRequests(tokenTwo);
     }
@@ -52,7 +52,7 @@ class ManageFriendRequestIntegrationTests extends AbstractIntegrationTest {
 
         utils.sendAPIPostRequest(ACCEPT_USER_ONE_URL, tokenTwo)
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
-                .body(equalTo(Result.FRIEND_NOT_REQUESTED.getMessage()));
+                .body("message", equalTo(Result.FRIEND_NOT_REQUESTED.getMessage()));
     }
 
     @Test
@@ -61,7 +61,7 @@ class ManageFriendRequestIntegrationTests extends AbstractIntegrationTest {
 
         utils.sendAPIPostRequest(REJECT_USER_ONE_URL, tokenTwo)
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
-                .body(equalTo(Result.FRIEND_NOT_REQUESTED.getMessage()));
+                .body("message", equalTo(Result.FRIEND_NOT_REQUESTED.getMessage()));
     }
 
     private void sendFriendRequest(String token) {
@@ -71,6 +71,6 @@ class ManageFriendRequestIntegrationTests extends AbstractIntegrationTest {
     private void checkThereAreNoRequests(String token) {
         utils.sendAPIGETRequest(REQUESTS_URL, token)
                 .statusCode(HttpStatus.SC_SUCCESS)
-                .body("", equalTo(Collections.emptyList()));
+                .body("data", equalTo(Collections.emptyList()));
     }
 }

--- a/src/test/java/pl/eukon05/eventboard/integration/user/RemoveFriendIntegrationTests.java
+++ b/src/test/java/pl/eukon05/eventboard/integration/user/RemoveFriendIntegrationTests.java
@@ -23,11 +23,11 @@ class RemoveFriendIntegrationTests extends AbstractIntegrationTest {
 
         utils.sendAPIPostRequest(REMOVE_URL, tokenOne)
                 .statusCode(HttpStatus.SC_SUCCESS)
-                .body(equalTo(Result.SUCCESS.getMessage()));
+                .body("message", equalTo(Result.SUCCESS.getMessage()));
 
         utils.sendAPIGETRequest(FRIENDS_URL, tokenOne)
                 .statusCode(HttpStatus.SC_SUCCESS)
-                .body("", equalTo(Collections.emptyList()));
+                .body("data", equalTo(Collections.emptyList()));
     }
 
     @Test
@@ -36,7 +36,7 @@ class RemoveFriendIntegrationTests extends AbstractIntegrationTest {
 
         utils.sendAPIPostRequest(REMOVE_URL, tokenOne)
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
-                .body(equalTo(Result.USER_NOT_FRIEND.getMessage()));
+                .body("message", equalTo(Result.USER_NOT_FRIEND.getMessage()));
     }
 
 }


### PR DESCRIPTION
- Rewrote ResultWrapper to act as a standardised way of sending response data to the client, no matter which operation was performed. The new response features the requested data, a message summarising the result of the operation, and, if required, additional details, such as validation errors or an ID of a newly created object.

- After creating a new event, the user receives its ID in the response body, as well as its URI in the LOCATION header.

- Validation errors are now sent to the client in the response, so that it can show an adequate error message.

- Facade classes convert all use-case outputs into ResultWrapper objects.